### PR TITLE
Change call to ServeUnix to work with latest Docker plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,10 +33,6 @@ deploy:
     - dist/docker-volume-glusterfs-${VERSION}-freebsd_amd64.tar.gz
     - dist/docker-volume-glusterfs-${VERSION}-freebsd_386.zip
     - dist/docker-volume-glusterfs-${VERSION}-freebsd_386.tar.gz
-    - dist/docker-volume-glusterfs-${VERSION}-windows_386.zip
-    - dist/docker-volume-glusterfs-${VERSION}-windows_386.tar.gz
-    - dist/docker-volume-glusterfs-${VERSION}-windows_amd64.zip
-    - dist/docker-volume-glusterfs-${VERSION}-windows_amd64.tar.gz
   skip_cleanup: true
   overwrite: true
   on:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ script:
 deploy:
   provider: releases
   api_key:
-    secure: s5RkXfiKMVjqp18enCNNbBH7wwUSVzdTP0jb9odDN76WvtPov1vt3BIgDm4/c8BW7oEpUE5sEqywPRd0m03XmQaZ7yZtK9ognmx2KiBsuiwQw0C6p5us5ftoNDyYPdXqLzQZDaAWyZ5Z1mwCMQLSDjPyCpwu/t5m9/n58tw8nNVEY0aHdhDwUgCJns3QQwLv60hE+Ux7Q71JfWd95PIvPz0MUQveg253Eaf+QYxOyHskLhRexv/rOQ85esT0E+6m6G3kTOPCAxfP4Ndcoy4sHKVWATz4muC9xC8iId5sSmbIM8rgFnIIDSpIyePuT8iHrBhhfpEhH3dzGc9IGXH8vuWu9NvBaIm+s9R4nhTjPxCVB6IRC3ziodFeg7DC2g5iTB4CsNAw61+AkMOL3bwYWttiKrLxVWaoHX/loU0ouoUGRQajEcCT+zcSoo58EkJ29RxvZaiwOeAOxcASGMcSI8gfSexdmP1d0JzwwuYBLe76B5L17hnoo3KYr+e6EHBJLrojYpt30tGOaBIYD5wf3fyyJD7Ncq5k++2z9C0US89cf6rKhoK9Tk6hJRq0Yo3/BwuOHP8uDyP1O/jjbt76i5LDpenAunoegWYpGReI8lXp/uEf2oGrvqattrogr8dU5IzjyYhsl+KnuxczHZ4Bw58k8MC6O+FRAZ0Eh407KOw=
+    secure: t+gv2I3ilkvP9O3EWjPiu/nSKzgUf1+lIpw5+CeG4yfqEY8LgfAYFELCqfBEygvNOq08whpMxh93xAS7eHhae+af4+SYIJ924th64XjlROrTMDy1n77kT2WKv61syNvy/+zpZBY+OS5f435MNhzln1C1sM74JVarACrAK4/swHXN9xHtUNggZosW4BA/cY0Gr7tZnWTf2A0qiqN2eUz8tSqdHrQ98dmBsRYNkKMIARUiyHGtCHZ7Ysz/5JQbLRbTgs/y4s7q5vwvEKSwvZapgMbzyOJhi85Hr1pAeYpEN3Ax8iw6Un8zyA+dzSmA3RZpkOuFQxSJaGHUj16mP5qvqgnCJsj8Oeg5wpzhFG2inAOxWc7+N+HTmxAIZWDF+isNuUfArjaYoQscqci/Kc1IPrPDj+JhAHfM3Y0yYhJYn7Dz9BpVn1GtblrlK2u43fjHFo4BiW/Zr4WW6kxP42A+9nYKkl8iHPxMjoBBhbA7bncitFCeVY9qIxAhaCPslHcKWPftvbMnSvGzQQd1GSE9BJlr/yiFvsdz+QxTDK090OLvH8LNhz+xpvrSmwz2NCkb/Wjll3wzsHb1eNL0vSB2XoHeTVIBfENhyDSDHlBJXkUinte6j12N/YcvYyS3oX+6XXU/9kTX/m5b38NwswFqzSkiFED8rzAD0j16q96ZhqE=
   file:
     - dist/docker-volume-glusterfs-${VERSION}-linux_amd64.zip
     - dist/docker-volume-glusterfs-${VERSION}-linux_amd64.tar.gz
@@ -41,3 +41,4 @@ deploy:
   overwrite: true
   on:
     tags: true
+    repo: watson81/docker-volume-glusterfs

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 
 BUILD               = $(shell git rev-parse HEAD)
 
-PLATFORMS           = linux_amd64 linux_386 linux_arm darwin_amd64 darwin_386 freebsd_amd64 freebsd_386 windows_386 windows_amd64
+PLATFORMS           = linux_amd64 linux_386 linux_arm darwin_amd64 darwin_386 freebsd_amd64 freebsd_386
 
 FLAGS_all           = GOPATH=$(GOPATH)
 FLAGS_linux_amd64   = $(FLAGS_all) GOOS=linux GOARCH=amd64

--- a/README.md
+++ b/README.md
@@ -2,15 +2,15 @@
 
 This plugin uses GlusterFS as distributed data storage for containers.
 
-[![Release](https://img.shields.io/github/release/amarkwalder/docker-volume-glusterfs.svg)](https://github.com/amarkwalder/docker-volume-glusterfs/releases/latest)
-[![TravisCI](https://travis-ci.org/amarkwalder/docker-volume-glusterfs.svg)](https://travis-ci.org/amarkwalder/docker-volume-glusterfs)
+[![Release](https://img.shields.io/github/release/watson81/docker-volume-glusterfs.svg)](https://github.com/watson81/docker-volume-glusterfs/releases/latest)
+[![TravisCI](https://travis-ci.org/watson81/docker-volume-glusterfs.svg)](https://travis-ci.org/watson81/docker-volume-glusterfs)
 
 ## Installation
 
 Using go (until we get proper binaries):
 
 ```
-$ go get github.com/amarkwalder/docker-volume-glusterfs
+$ go get github.com/watson81/docker-volume-glusterfs
 ```
 
 ## Usage

--- a/driver.go
+++ b/driver.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/amarkwalder/docker-volume-glusterfs/rest"
+	"github.com/watson81/docker-volume-glusterfs/rest"
 	"github.com/docker/go-plugins-helpers/volume"
 )
 

--- a/main.go
+++ b/main.go
@@ -46,7 +46,7 @@ func main() {
 
 	d := newGlusterfsDriver(*root, *restAddress, *gfsBase, servers)
 	h := volume.NewHandler(d)
-	fmt.Println(h.ServeUnix("root", "glusterfs"))
+	fmt.Println(h.ServeUnix("glusterfs", 0))
 }
 
 func banner() {


### PR DESCRIPTION
https://github.com/docker/go-plugins-helpers/commit/0af5adef105c32d8ad1a58269f26a783a96d522f changes the interface to ServeUnix. The new API removes the group name lookup and re-orders the parameters. Since the linux superuser must always have UID & GID 0, using a hardcoded GID of 0 is just as good as the previous code.